### PR TITLE
Not crashing when version is not present

### DIFF
--- a/fetch_licenses.swift
+++ b/fetch_licenses.swift
@@ -20,7 +20,7 @@ struct CartfileEntry: CustomStringConvertible {
         let line = line.replacingOccurrences(of: "github ", with: "")
         let components = line.components(separatedBy: "\" \"")
         name = components[0].replacingOccurrences(of: "\"", with: "")
-        version = components[1].replacingOccurrences(of: "\"", with: "")
+        version = components.count > 1 ? components[1].replacingOccurrences(of: "\"", with: "") : ""
     }
 
     var projectName: String {


### PR DESCRIPTION
In `Carthage` it is valid to define a dependency without version, just as `github "cruffenach/CRToast"` for example and many libraries encourage you to do so because they do not do version releases.  This PR fixes the script crashing on such definitions.